### PR TITLE
AV-65755: avi-lbaas endpoint lookup fails (#44)

### DIFF
--- a/avi/heat/avi_resource.py
+++ b/avi/heat/avi_resource.py
@@ -70,9 +70,18 @@ class AviResource(resource.Resource):
         if address:
             return address
         try:
-            endpoint = self.client("keystone").url_for(
-                service_type="avi-lbaas",
-                endpoint_type="publicURL")
+            c = self.client('keystone')
+            if not hasattr(c, 'url_for'):
+                c = self.client_plugin('keystone')
+
+            if not hasattr(c, 'url_for'):
+                LOG.error("Couldn't find keystone plugin or client to ",
+                          "get url_for avi-lbaas service, Avi driver ",
+                          "will not work!")
+                return None
+
+            endpoint = c.url_for(service_type="avi-lbaas",
+                                 endpoint_type="publicURL")
             address = endpoint.split("//")[1].split("/")[0]
         except Exception as e:
             LOG.exception("Error during finding avi address: %s", e)


### PR DESCRIPTION
Avi Controller network location (HTTP(S) + IP address + port) can be
specified by creating a Keystone endpoint in OpenStack. Avi Heat Plugin
reads the endpoint from Keystone catalog and connects to Avi Controller.

However, from Pike release onwards, the Keystone client in Heat (class
named KsClientWrapper) doesn't support the 'url_for' mechanism to fetch
the endpoints. It has been moved to client_plugin class. The Avi driver,
therefore fails to get the endpoint and cannot CRUD Avi resources.

Check https://review.opendev.org/#/c/429491/ for more details.

Fix is to check for both client and client_plugin for Keystone service.
Checking in both would make sure the driver doesn't break for Pike and
older versions.